### PR TITLE
fix: multiple memcpy operations in luat_vfs in luat_vfs.c

### DIFF
--- a/luat/vfs/luat_vfs.c
+++ b/luat/vfs/luat_vfs.c
@@ -347,15 +347,22 @@ int luat_fs_lsdir(char const* _DirName, luat_fs_dirent_t* ents, size_t offset, s
 
     char file_path[256] = {0};
     size_t file_path_len = strlen(_DirName);
+    if (file_path_len >= sizeof(file_path) - 1)
+        return ret;
     memcpy(file_path, _DirName, file_path_len + 1);
     if (strlen(_DirName + strlen(mount->prefix))!=1){
+        if (file_path_len + 1 >= sizeof(file_path) - 1)
+            return ret;
         file_path[file_path_len] = '/';
         file_path[file_path_len + 1] = 0;
         file_path_len++;
     }
     for (size_t i = 0; i < ret; i++){
         if (ents[i].d_type==0){
-            memcpy(file_path+file_path_len, ents[i].d_name, strlen(ents[i].d_name) + 1);
+            size_t name_len = strlen(ents[i].d_name);
+            if (file_path_len + name_len >= sizeof(file_path) - 1)
+                continue;
+            memcpy(file_path+file_path_len, ents[i].d_name, name_len + 1);
             ents[i].d_size = luat_fs_fsize(file_path);
         }
     }


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `luat/vfs/luat_vfs.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `luat/vfs/luat_vfs.c:350` |

**Description**: Multiple memcpy operations in luat_vfs.c use lengths derived from source strings (strlen + 1) without verifying that the destination buffer is large enough to hold the data. At line 350, file_path_len is computed from _DirName but the allocated file_path buffer size is not validated against the actual string length before copying. At line 358, ents[i].d_name is appended to file_path without checking remaining buffer capacity. An attacker who can influence directory names or mount point strings can trigger a heap or stack overflow.

## Changes
- `luat/vfs/luat_vfs.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
